### PR TITLE
Implement winningest managerial seasons example

### DIFF
--- a/example.R
+++ b/example.R
@@ -1,4 +1,16 @@
-setwd("C:/Users/lazen/OneDrive/Documents/GitHub/example_codex_project")
+# Example script using Lahman data
 
 library(tidyverse)
+library(Lahman)
 library(baseballr)
+
+# top 50 winningest managerial seasons since 1960
+manager_seasons <- Managers %>%
+  filter(yearID >= 1960) %>%
+  left_join(Teams %>% select(yearID, teamID, team_name = name, WSWin), by = c("yearID", "teamID")) %>%
+  left_join(People %>% select(playerID, nameFirst, nameLast), by = "playerID") %>%
+  mutate(manager = paste(nameFirst, nameLast),
+         wonWS = WSWin == "Y") %>%
+  arrange(desc(W)) %>%
+  select(yearID, manager, team_name, W, wonWS) %>%
+  slice_head(n = 50)


### PR DESCRIPTION
## Summary
- update example.R to load Lahman and produce a data frame of the top 50 winningest managerial seasons since 1960

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684cbfc55ed48324b79b40d4ba5e4f09